### PR TITLE
build: Add meson build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,11 @@ The RPMs can be downloaded from the [bign-handheld-thumbnailer COPR](https://cop
 
 ### Manual
 
-There are three pieces to get the thumbnailer running: a compiled `bign-handheld-thumbnailer` binary, the `bign-handheld-thumbnailer.thumbnailer` file and the needed mime type definitions from `bign-handheld-thumbnailer-3ds.xml`.
+You will need a Rust development environment and meson installed to
+install the binaries and data files:
+```
+meson setup _build -Dprefix=/usr
+ninja -C _build install
+```
 
-Due to nautilus using a sandbox to run thumbnailers it's needed to install the binary in a place where the sandbox can access it, such as `/usr/bin`.
-
-1. Compile the project with `cargo build --release`
-2. Copy the compiled binary to /usr/bin (e.g. `sudo cp target/release/bign-handheld-thumbnailer /usr/bin/`)
-3. Copy `bign-handheld-thumbnailer-3ds.xml` to `/usr/share/mime/packages/` to install the needed mime type definition system-wide
-4. Run `sudo update-mime-database /usr/share/mime` so the system-wide mime type database is updated based on the newly-added configuration
-5. Copy the `bign-handheld-thumbnailer.thumbnailer` file to `~/.local/share/thumbnailers` (user-install) or `/usr/share/thumbnailers` (system-install)
-6. At this point thumbnails should be working, you likely will want to restart the file explorer or clear the cached thumbnails
+At this point thumbnails should be working, you likely will want to restart the file explorer or clear the cached thumbnails

--- a/bign-handheld-thumbnailer.thumbnailer.in
+++ b/bign-handheld-thumbnailer.thumbnailer.in
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
-TryExec=/usr/bin/bign-handheld-thumbnailer
-Exec=/usr/bin/bign-handheld-thumbnailer -s %s %i %o
+TryExec=@bindir@/bign-handheld-thumbnailer
+Exec=@bindir@/bign-handheld-thumbnailer -s %s %i %o
 MimeType=application/x-nintendo-ds-rom;application/x-ctr-cia;application/x-ctr-smdh;application/x-ctr-3dsx;application/x-nintendo-3ds-executable;application/x-ctr-cxi;application/x-ctr-cci;application/x-nintendo-3ds-rom;

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,8 @@ install_data(
     install_dir: get_option('datadir') / 'mime/packages',
 )
 
-gnome.post_install(
-    update_mime_database: true
-)
+if get_option('update_mime_database')
+  gnome.post_install(
+      update_mime_database: true
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,51 @@
+project('bign-handheld-thumbnailer', 'rust',
+  version: '1.0.0',
+  license: 'GPL-2.0-or-later',
+  meson_version: '>= 0.64.0')
+
+gnome = import('gnome')
+
+prefix = get_option('prefix')
+bindir = prefix / get_option('bindir')
+thumbnailers_dir = prefix / get_option('datadir') / 'thumbnailers'
+
+cargo_bin  = find_program('cargo')
+cargo_opt  = [ '--manifest-path', meson.project_source_root() / 'Cargo.toml' ]
+cargo_opt += [ '--target-dir', meson.project_build_root()  / 'src' ]
+cargo_env  = [ 'CARGO_HOME=' + meson.project_build_root()  / 'cargo-home' ]
+
+if get_option('buildtype') == 'release'
+  cargo_opt += [ '--release' ]
+  rust_target = 'release'
+else
+  rust_target = 'debug'
+endif
+
+cargo_build = custom_target(
+  'cargo-build',
+  build_by_default: true,
+  build_always_stale: true,
+  output: meson.project_name(),
+  console: true,
+  install: true,
+  install_dir: get_option('bindir'),
+  command: [
+    'env', cargo_env,
+    cargo_bin, 'build',
+    cargo_opt, '&&', 'cp', 'src' / rust_target / meson.project_name(), '@OUTPUT@',
+  ]
+)
+
+configure_file(input : meson.project_name() + '.thumbnailer.in',
+               output : meson.project_name() + '.thumbnailer',
+               configuration : {'bindir' : bindir},
+               install_dir : thumbnailers_dir)
+
+install_data(
+    'bign-handheld-thumbnailer-3ds.xml',
+    install_dir: get_option('datadir') / 'mime/packages',
+)
+
+gnome.post_install(
+    update_mime_database: true
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('update_mime_database', type: 'boolean', value: true, description: 'Whether to run update-mime-database after installation')


### PR DESCRIPTION
This simplifies the installation of necessary data files for the thumbnailer to work, working around this long-standing RFE: https://github.com/rust-lang/cargo/issues/2729

Ideally, meson would also be used to compile the binary instead of Cargo, but meson doesn't easily support external crates: https://github.com/mesonbuild/meson/issues/2173